### PR TITLE
bug fix for profile pictures on likes, reposts, etc

### DIFF
--- a/semantic-linkbacks-microformats-handler.php
+++ b/semantic-linkbacks-microformats-handler.php
@@ -177,7 +177,7 @@ class SemanticLinkbacksPlugin_MicroformatsHandler {
     $type = self::get_entry_type($target, $entry, $mf_array);
 
     // remove "webmention" comment-type if $type is "reply"
-    if ($type == "reply") {
+    if ($type == "reply" || $type == "like" || $type == "repost" || $type == "favorite") {
       global $wpdb;
 
       $wpdb->update( $wpdb->comments, array( 'comment_type' => '' ), array( 'comment_ID' => $commentdata["comment_ID"] ) );


### PR DESCRIPTION
this is what originally caused #8 for me. not sure how having comment_type 'webmention' prevents the comment avatars from displaying, but this clears it, which makes them show up again.

sorry for the extra commits in the PR. i tried to fork your fork, but github made it a fork of acegiak's original repo. adding yours as a remote helped, but not entirely. feel free to just make this change in your repo manually and close this PR.
