### PR TITLE
Switch Filter from get_avatar to pre_get_avatar_data

### DIFF
--- a/semantic-linkbacks.php
+++ b/semantic-linkbacks.php
@@ -46,9 +46,7 @@ class SemanticLinkbacksPlugin {
     add_action('pingback_post', array('SemanticLinkbacksPlugin', 'linkback_fix'));
     add_action('trackback_post', array('SemanticLinkbacksPlugin', 'linkback_fix'));
     add_action('webmention_post', array('SemanticLinkbacksPlugin', 'linkback_fix'));
-
-    add_filter('get_avatar', array('SemanticLinkbacksPlugin', 'get_avatar'), 11, 5);
-
+    add_filter('pre_get_avatar_data', array('SemanticLinkbacksPlugin', 'pre_get_avatar_data'), 11, 5);
     // To extend or to override the default behavior, just use the `comment_text` filter with a lower
     // priority (so that it's called after this one) or remove the filters completely in
     // your code: `remove_filter('comment_text', array('SemanticLinkbacksPlugin', 'comment_text_add_cite'), 11);`
@@ -337,35 +335,26 @@ class SemanticLinkbacksPlugin {
   /**
    * replaces the default avatar with the WebMention uf2 photo
    *
-   * @param string $avatar the avatar-url
+   * @param array $args Arguments passed to get_avatar_data(), after processing.
    * @param int|string|object $id_or_email A user ID, email address, or comment object
-   * @param int $size Size of the avatar image
-   * @param string $default URL to a default image to use if no avatar is available
-   * @param string $alt Alternative text to use in image tag. Defaults to blank
-   * @return string new avatar-url
+   * @return array $args
    */
-  public static function get_avatar($avatar, $id_or_email, $size, $default = '', $alt = '') {
+  public static function pre_get_avatar_data($args, $id_or_email) {
+    if(!isset($args['class']) ) {
+        $args['class']=array('u-photo');
+    }
     if (!is_object($id_or_email) ||
         !isset($id_or_email->comment_type) ||
         !get_comment_meta($id_or_email->comment_ID, 'semantic_linkbacks_avatar', true)) {
-      return $avatar;
+      return $args;
     }
-
     // check if comment has an avatar
     $sl_avatar = get_comment_meta($id_or_email->comment_ID, 'semantic_linkbacks_avatar', true);
-
-    if (!$sl_avatar) {
-      return $avatar;
+    if ($sl_avatar) {
+      $args['url']=$sl_avatar;
+      $args['class'][]='avatar-semantic-linkbacks';
     }
-
-    if (false === $alt) {
-      $safe_alt = '';
-    } else {
-      $safe_alt = esc_attr($alt);
-    }
-
-    $avatar = "<img alt='{$safe_alt}' src='{$sl_avatar}' class='avatar avatar-{$size} photo u-photo avatar-semantic-linkbacks' height='{$size}' width='{$size}' />";
-    return $avatar;
+    return $args;
   }
 
   /**

--- a/semantic-linkbacks.php
+++ b/semantic-linkbacks.php
@@ -341,8 +341,11 @@ class SemanticLinkbacksPlugin {
    */
   public static function pre_get_avatar_data($args, $id_or_email) {
     if(!isset($args['class']) ) {
-        $args['class']=array('u-photo');
+      $args['class']=array('u-photo');
     }
+    else {
+      $args['class'][]='u-photo';
+    }  
     if (!is_object($id_or_email) ||
         !isset($id_or_email->comment_type) ||
         !get_comment_meta($id_or_email->comment_ID, 'semantic_linkbacks_avatar', true)) {


### PR DESCRIPTION
Referenced in #23 . 

The pre_get_avatar_data filter over the get_avatar filter fires before the call to gravatar and allows for finer control.

Also, as the changes allow classes to be added to the avatar without generating the entire markup, this seems to be less intrusive.