### PR TITLE
Use Passed Along Target and Minor Fixes

### DIFF
--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -101,19 +101,20 @@ class Linkbacks_Handler {
 			$commentdata['comment_meta'] = array();
 		}
 
-		// generate target
-		$target = get_permalink( $commentdata['comment_post_ID'] );
-
+		//  If target is not set then set based on permalink
+		if ( ! isset( $commentdata['target'] ) ) {
+			$commentdata['target'] = get_permalink( $commentdata['comment_post_ID'] );
+		}
 		// add replytocom if present
 		if ( isset( $commentdata['comment_parent'] ) && ! empty( $commentdata['comment_parent'] ) ) {
-			$target = add_query_arg( array( 'replytocom' => $commentdata['comment_parent'] ), $target );
+			$commentdata['target'] = add_query_arg( array( 'replytocom' => $commentdata['comment_parent'] ), $commentdata['target'] );
 		}
 
 		// add source url as comment-meta
 		$commentdata['comment_meta']['semantic_linkbacks_source'] = esc_url_raw( $commentdata['comment_author_url'] );
 
 		// adds a hook to enable some other semantic handlers for example schema.org
-		$commentdata = apply_filters( 'semantic_linkbacks_commentdata', $commentdata, $target );
+		$commentdata = apply_filters( 'semantic_linkbacks_commentdata', $commentdata );
 
 		// remove "webmention" comment-type if $type is "reply"
 		if ( isset( $commentdata['comment_meta']['semantic_linkbacks_type'] ) ) {
@@ -479,7 +480,7 @@ class Linkbacks_Handler {
 		$types[] = 'trackback';
 		$types[] = 'webmention';
 
-		return $types;
+		return array_unique( $types );
 	}
 
 }

--- a/includes/class-linkbacks-mf2-handler.php
+++ b/includes/class-linkbacks-mf2-handler.php
@@ -100,11 +100,10 @@ class Linkbacks_MF2_Handler {
 	 * generate the comment data from the microformatted content
 	 *
 	 * @param WP_Comment $commentdata the comment object
-	 * @param string $target the target url
 	 *
 	 * @return array
 	 */
-	public static function generate_commentdata( $commentdata, $target ) {
+	public static function generate_commentdata( $commentdata ) {
 		global $wpdb;
 
 		// add source
@@ -122,7 +121,7 @@ class Linkbacks_MF2_Handler {
 		}
 
 		// get the entry of interest
-		$entry = self::get_representative_entry( $entries, $target );
+		$entry = self::get_representative_entry( $entries, $commentdata['target'] );
 
 		if ( empty( $entry ) ) {
 			return array();
@@ -191,7 +190,7 @@ class Linkbacks_MF2_Handler {
 			$commentdata['comment_meta']['semantic_linkbacks_type'] = wp_slash( 'rsvp:' . $properties['rsvp'][0] );
 		} else {
 			// get post type
-			$commentdata['comment_meta']['semantic_linkbacks_type'] = wp_slash( self::get_entry_type( $target, $entry, $mf_array ) );
+			$commentdata['comment_meta']['semantic_linkbacks_type'] = wp_slash( self::get_entry_type( $commentdata['target'], $entry, $mf_array ) );
 		}
 
 		return $commentdata;
@@ -406,6 +405,9 @@ class Linkbacks_MF2_Handler {
 	 * @return boolean
 	 */
 	public static function compare_urls( $needle, $haystack, $schemeless = true ) {
+		if ( ! is_string( $needle ) || ! is_array( $haystack ) ) {
+			return false;
+		}
 		if ( true === $schemeless ) {
 			// remove url-scheme
 			$schemeless_target = preg_replace( '/^https?:\/\//i', '', $needle );


### PR DESCRIPTION
When I was testing webmention fragments, I discovered Semantic Linkbacks stripped the fragment if enabled. This addresses that by using the target URL if passed in the commentdata array and only using the return from get_permalink if nothing is passed.

It also checks to make sure a string and an array are pased to compare_urls, due an array to string conversion error I was getting. 