### PR TITLE
Resolves adactio-com test

### DIFF
--- a/includes/class-linkbacks-mf2-handler.php
+++ b/includes/class-linkbacks-mf2-handler.php
@@ -184,6 +184,9 @@ class Linkbacks_MF2_Handler {
 				if ( isset( $properties['name'] ) ) {
 					$commentdata['comment_author'] = wp_slash( $author['name'] );
 				}
+				if ( isset( $author['properties']['name'] ) && empty( $commentdata['comment_author'] ) ){
+					$commentdata['comment_author'] = wp_slash( $author['properties']['name'][0] );
+				}
 
 				if ( isset( $author['email'] ) ) {
 					$commentdata['comment_author_email'] = wp_slash( $author['email'] );


### PR DESCRIPTION
I don't like this as a solution. I don't grok the parser to understand _why_ this resolves it, but alas it does. Hopefully it can help y'all a bit.

For the failing Sandeep test, the `$properties` array doesn't include the author name at all, so something is failing higher up the stack.

See #91 