### PR TITLE
fix avatar aspect ratios with object-fit: cover instead of fill

### DIFF
--- a/css/semantic-linkbacks.css
+++ b/css/semantic-linkbacks.css
@@ -17,5 +17,5 @@
 	height: 64px;
 	width: 64px;
 	display: block;
-	object-fit: fill;
+	object-fit: cover;
 }


### PR DESCRIPTION
fixes #115. tentatively suggesting @dshanske review since he originally added `object-fit: fill` in d0ca8ed2aeb287bddca027322f9f91a61b0f9598.

background:
https://css-tricks.com/almanac/properties/o/object-fit/
https://caniuse.com/#feat=object-fit

thanks in advance!