### PR TITLE
 facepiles: add settings to enable each type independently

### DIFF
--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -9,15 +9,26 @@ define( 'MAX_INLINE_MENTION_LENGTH', 300 );
  * Based on https://codex.wordpress.org/Function_Reference/Walker_Comment
  */
 class Semantic_Linkbacks_Walker_Comment extends Walker_Comment {
+	static function should_facepile( $comment ) {
+		if ( $comment->type && $comment_type != 'comment' ) {
+			$type = 'mention';
+		} else {
+			$type = Linkbacks_Handler::get_type ( $comment );
+		}
+		$option = 'semantic_linkbacks_facepile_' . explode( ':', $type )[0];
+
+		return $type && $type != 'reply' && get_option( $option, true );
+	}
+
 	function start_el( &$output, $comment, $depth = 0, $args = array(), $id = 0 ) {
-		if ( $comment->type != 'webmention' || Linkbacks_Handler::get_type ( $comment ) == 'mention' ) {
-			return parent::start_el ( $output, $comment, $depth, $args, $id );
+		if ( ! self::should_facepile( $comment ) ) {
+			return parent::start_el( $output, $comment, $depth, $args, $id );
 		}
 	}
 
 	function end_el( &$output, $comment, $depth = 0, $args = array() ) {
-		if ( $comment->type != 'webmention' || Linkbacks_Handler::get_type ( $comment ) == 'mention' ) {
-			return parent::end_el ( $output, $comment, $depth, $args, $id );
+		if ( ! self::should_facepile( $comment ) ) {
+			return parent::end_el( $output, $comment, $depth, $args, $id );
 		}
 	}
 }
@@ -51,11 +62,8 @@ class Linkbacks_Handler {
 		add_filter( 'get_comment_author_url', array( 'Linkbacks_Handler', 'get_comment_author_url' ), 99, 3 );
 		add_filter( 'get_avatar_comment_types', array( 'Linkbacks_Handler', 'get_avatar_comment_types' ) );
 		add_filter( 'comment_class', array( 'Linkbacks_Handler', 'comment_class' ), 10, 4 );
-
-		if ( 1 == get_option( 'semantic_linkbacks_facepiles' ) ) {
-			add_filter( 'wp_list_comments_args', array( 'Linkbacks_Handler', 'filter_comment_args' ) );
-			add_action( 'comment_form_before', array( 'Linkbacks_Handler', 'show_mentions' ) );
-		}
+		add_filter( 'wp_list_comments_args', array( 'Linkbacks_Handler', 'filter_comment_args' ) );
+		add_action( 'comment_form_before', array( 'Linkbacks_Handler', 'show_mentions' ) );
 
 		// Register Meta Keys
 		self::register_meta();

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -4,6 +4,25 @@
 define( 'MAX_INLINE_MENTION_LENGTH', 300 );
 
 /**
+ * Comment walker subclass that skips facepile webmention comments.
+ *
+ * Based on https://codex.wordpress.org/Function_Reference/Walker_Comment
+ */
+class Semantic_Linkbacks_Walker_Comment extends Walker_Comment {
+	function start_el( &$output, $comment, $depth = 0, $args = array(), $id = 0 ) {
+		if ( $comment->type != 'webmention' || Linkbacks_Handler::get_type ( $comment ) == 'mention' ) {
+			return parent::start_el ( $output, $comment, $depth, $args, $id );
+		}
+	}
+
+	function end_el( &$output, $comment, $depth = 0, $args = array() ) {
+		if ( $comment->type != 'webmention' || Linkbacks_Handler::get_type ( $comment ) == 'mention' ) {
+			return parent::end_el ( $output, $comment, $depth, $args, $id );
+		}
+	}
+}
+
+/**
  * Semantic linkbacks class
  *
  * @author Matthias Pfefferle
@@ -43,15 +62,14 @@ class Linkbacks_Handler {
 	}
 
 	/**
-	  * Filter the comments and ignore every comment other than 'comment'
+	  * Filter the comments and ignore every comment other than 'comment' and 'mention'
 	  *
 	  * @param array $args an array of arguments for displaying comments
 	  *
 	  * @return array the filtered array
 	  */
 	public static function filter_comment_args( $args ) {
-		$args['type'] = 'comment';
-
+		$args['walker'] = new Semantic_Linkbacks_Walker_Comment;
 		return $args;
 	}
 

--- a/semantic-linkbacks.php
+++ b/semantic-linkbacks.php
@@ -45,9 +45,45 @@ class Semantic_Linkbacks_Plugin {
 
 	public static function admin_init() {
 		add_settings_field( 'semantic_linkbacks_discussion_settings', __( 'Semantic Linkbacks Settings', 'webmention' ), array( 'Semantic_Linkbacks_Plugin', 'discussion_settings' ), 'discussion', 'default' );
-		register_setting( 'discussion', 'semantic_linkbacks_facepiles', array(
+		register_setting( 'discussion', 'semantic_linkbacks_facepile_mention', array(
 			'type' => 'boolean',
-			'description' => __( 'Automatically Create Facepiles', 'semantic-linkbacks' ),
+			'description' => __( 'Facepile Mentions', 'semantic-linkbacks' ),
+			'show_in_rest' => true,
+			'default' => 1,
+		) );
+		register_setting( 'discussion', 'semantic_linkbacks_facepile_repost', array(
+			'type' => 'boolean',
+			'description' => __( 'Facepile Reposts', 'semantic-linkbacks' ),
+			'show_in_rest' => true,
+			'default' => 1,
+		) );
+		register_setting( 'discussion', 'semantic_linkbacks_facepile_like', array(
+			'type' => 'boolean',
+			'description' => __( 'Facepile Likes', 'semantic-linkbacks' ),
+			'show_in_rest' => true,
+			'default' => 1,
+		) );
+		register_setting( 'discussion', 'semantic_linkbacks_facepile_favorite', array(
+			'type' => 'boolean',
+			'description' => __( 'Facepile Favorite', 'semantic-linkbacks' ),
+			'show_in_rest' => true,
+			'default' => 1,
+		) );
+		register_setting( 'discussion', 'semantic_linkbacks_facepile_tag', array(
+			'type' => 'boolean',
+			'description' => __( 'Facepile Tags', 'semantic-linkbacks' ),
+			'show_in_rest' => true,
+			'default' => 1,
+		) );
+		register_setting( 'discussion', 'semantic_linkbacks_facepile_bookmark', array(
+			'type' => 'boolean',
+			'description' => __( 'Facepile Bookmarks', 'semantic-linkbacks' ),
+			'show_in_rest' => true,
+			'default' => 1,
+		) );
+		register_setting( 'discussion', 'semantic_linkbacks_facepile_rsvp', array(
+			'type' => 'boolean',
+			'description' => __( 'Facepile RSVPs', 'semantic-linkbacks' ),
 			'show_in_rest' => true,
 			'default' => 1,
 		) );

--- a/templates/discussion-settings.php
+++ b/templates/discussion-settings.php
@@ -1,12 +1,36 @@
 <fieldset id="semantic_linkbacks">
 	<?php if ( apply_filters( 'semantic_linkbacks_facepiles', true ) ) { ?>
-	<label for="semantic_linkbacks_facepiles">
-		<input type="checkbox" name="semantic_linkbacks_facepiles" id="semantic_linkbacks_facepiles" value="1" <?php
-			echo checked( true, get_option( 'semantic_linkbacks_facepiles' ) );  ?> />
-		<?php _e( 'Automatically embed facepile <small>(May not work on all themes)</small>', 'semantic-linkbacks' ) ?>
-	</label>
-
-	<br />
+	<?php _e( 'Automatically embed facepiles <small>(may not work on all themes)</small> for:', 'semantic-linkbacks' ) ?>
+    <ul>
+    <li><label for="semantic_linkbacks_facepile_mention">
+		<input type="checkbox" name="semantic_linkbacks_facepile_mention" id="semantic_linkbacks_facepile_mention" value="1" <?php echo checked( true, get_option( 'semantic_linkbacks_facepile_mention', true ) ); ?> />
+		<?php _e( 'Mentions', 'semantic-linkbacks' ) ?>
+	</label></li>
+    <li><label for="semantic_linkbacks_facepile_repost">
+		<input type="checkbox" name="semantic_linkbacks_facepile_repost" id="semantic_linkbacks_facepile_repost" value="1" <?php echo checked( true, get_option( 'semantic_linkbacks_facepile_repost', true ) ); ?> />
+		<?php _e( 'Reposts', 'semantic-linkbacks' ) ?>
+	</label></li>
+    <li><label for="semantic_linkbacks_facepile_like">
+		<input type="checkbox" name="semantic_linkbacks_facepile_like" id="semantic_linkbacks_facepile_like" value="1" <?php echo checked( true, get_option( 'semantic_linkbacks_facepile_like', true ) ); ?> />
+		<?php _e( 'Likes', 'semantic-linkbacks' ) ?>
+	</label></li>
+    <li><label for="semantic_linkbacks_facepile_favorite">
+		<input type="checkbox" name="semantic_linkbacks_facepile_favorite" id="semantic_linkbacks_facepile_favorite" value="1" <?php echo checked( true, get_option( 'semantic_linkbacks_facepile_favorite', true ) ); ?> />
+		<?php _e( 'Favorites', 'semantic-linkbacks' ) ?>
+	</label></li>
+    <li><label for="semantic_linkbacks_facepile_tag">
+		<input type="checkbox" name="semantic_linkbacks_facepile_tag" id="semantic_linkbacks_facepile_tag" value="1" <?php echo checked( true, get_option( 'semantic_linkbacks_facepile_tag', true ) ); ?> />
+		<?php _e( 'Tags', 'semantic-linkbacks' ) ?>
+	</label></li>
+    <li><label for="semantic_linkbacks_facepile_bookmark">
+		<input type="checkbox" name="semantic_linkbacks_facepile_bookmark" id="semantic_linkbacks_facepile_bookmark" value="1" <?php echo checked( true, get_option( 'semantic_linkbacks_facepile_bookmark', true ) ); ?> />
+		<?php _e( 'Bookmarks', 'semantic-linkbacks' ) ?>
+	</label></li>
+    <li><label for="semantic_linkbacks_facepile_rsvp">
+		<input type="checkbox" name="semantic_linkbacks_facepile_rsvp" id="semantic_linkbacks_facepile_rsvp" value="1" <?php echo checked( true, get_option( 'semantic_linkbacks_facepile_rsvp', true ) ); ?> />
+		<?php _e( 'RSVPs', 'semantic-linkbacks' ) ?>
+	</label></li>
+	</ul>
 
 	<label for="semantic_linkbacks_facepiles_fold_limit">
 		<input type="number" min="0" step="1" name="semantic_linkbacks_facepiles_fold_limit" id="semantic_linkbacks_facepiles_fold_limit" class="small-text" value="<?php

--- a/templates/linkbacks.php
+++ b/templates/linkbacks.php
@@ -148,17 +148,3 @@
 	<?php endif; ?>
 </div>
 <?php endif; ?>
-
-<?php if ( has_linkbacks( 'mention' ) ) : ?>
-<div class="mentions">
-	<h3><?php echo __( 'Mentions', 'semantic-linkbacks' ); ?></h3>
-	<?php
-	list_linkbacks(
-		array(
-			'li-class' => array( 'single-mention', 'p-mention' ),
-		),
-		get_linkbacks( 'mention' )
-	);
-	?>
-</div>
-<?php endif; ?>

--- a/templates/linkbacks.php
+++ b/templates/linkbacks.php
@@ -1,4 +1,4 @@
-<?php if ( has_linkbacks( 'like' ) ) : ?>
+<?php if ( get_option( 'semantic_linkbacks_facepile_like', true ) && has_linkbacks( 'like' ) ) : ?>
 <div class="likes">
 	<h3><?php echo __( 'Likes', 'semantic-linkbacks' ); ?></h3>
 	<?php
@@ -12,7 +12,7 @@
 </div>
 <?php endif; ?>
 
-<?php if ( has_linkbacks( 'favorite' ) ) : ?>
+<?php if ( get_option( 'semantic_linkbacks_facepile_favorite', true ) && has_linkbacks( 'favorite' ) ) : ?>
 <div class="favorites">
 	<h3><?php echo __( 'Favourites', 'semantic-linkbacks' ); ?></h3>
 	<?php
@@ -26,7 +26,7 @@
 </div>
 <?php endif; ?>
 
-<?php if ( has_linkbacks( 'bookmark' ) ) : ?>
+<?php if ( get_option( 'semantic_linkbacks_facepile_bookmark', true ) && has_linkbacks( 'bookmark' ) ) : ?>
 <div class="bookmarks">
 	<h3><?php echo __( 'Bookmarks', 'semantic-linkbacks' ); ?></h3>
 	<?php
@@ -40,7 +40,7 @@
 </div>
 <?php endif; ?>
 
-<?php if ( has_linkbacks( 'repost' ) ) : ?>
+<?php if ( get_option( 'semantic_linkbacks_facepile_repost', true ) && has_linkbacks( 'repost' ) ) : ?>
 <div class="reposts">
 	<h3><?php echo __( 'Reposts', 'semantic-linkbacks' ); ?></h3>
 	<?php
@@ -54,7 +54,7 @@
 </div>
 <?php endif; ?>
 
-<?php if ( has_linkbacks( 'tag' ) ) : ?>
+<?php if ( get_option( 'semantic_linkbacks_facepile_tag', true ) && has_linkbacks( 'tag' ) ) : ?>
 <div class="tags">
 	<h3><?php echo __( 'Tags', 'semantic-linkbacks' ); ?></h3>
 	<?php
@@ -68,7 +68,7 @@
 </div>
 <?php endif; ?>
 
-<?php if ( has_linkbacks( 'rsvp' ) ) : ?>
+<?php if ( get_option( 'semantic_linkbacks_facepile_rsvp', true ) && has_linkbacks( 'rsvp' ) ) : ?>
 <div class="rsvps">
 	<h3><?php _e( 'RSVPs', 'semantic-linkbacks' ); ?></h3>
 
@@ -87,7 +87,7 @@
 	?>
 	<?php endif; ?>
 
-	<?php if ( has_linkbacks( 'rsvp:invited' ) ) : ?>
+	<?php if ( get_option( 'semantic_linkbacks_facepile_rsvp', true ) && has_linkbacks( 'rsvp:invited' ) ) : ?>
 	<h4><?php _e( 'Invited', 'semantic-linkbacks' ); ?></h4>
 	<?php
 	list_linkbacks(
@@ -102,7 +102,7 @@
 	?>
 	<?php endif; ?>
 
-	<?php if ( has_linkbacks( 'rsvp:maybe' ) ) : ?>
+	<?php if ( get_option( 'semantic_linkbacks_facepile_rsvp', true ) && has_linkbacks( 'rsvp:maybe' ) ) : ?>
 	<h4><?php _e( 'Maybe', 'semantic-linkbacks' ); ?></h4>
 	<?php
 	list_linkbacks(
@@ -117,7 +117,7 @@
 	?>
 	<?php endif; ?>
 
-	<?php if ( has_linkbacks( 'rsvp:no' ) ) : ?>
+	<?php if ( get_option( 'semantic_linkbacks_facepile_rsvp', true ) && has_linkbacks( 'rsvp:no' ) ) : ?>
 	<h4><?php _e( 'No', 'semantic-linkbacks' ); ?></h4>
 	<?php
 	list_linkbacks(
@@ -132,7 +132,7 @@
 	?>
 	<?php endif; ?>
 
-	<?php if ( has_linkbacks( 'rsvp:tracking' ) ) : ?>
+	<?php if ( get_option( 'semantic_linkbacks_facepile_rsvp', true ) && has_linkbacks( 'rsvp:tracking' ) ) : ?>
 	<h4><?php _e( 'Tracking', 'semantic-linkbacks' ); ?></h4>
 	<?php
 	list_linkbacks(
@@ -146,5 +146,19 @@
 	);
 	?>
 	<?php endif; ?>
+</div>
+<?php endif; ?>
+
+<?php if ( get_option( 'semantic_linkbacks_facepile_mention', true ) && has_linkbacks( 'mention' ) ) : ?>
+<div class="mentions">
+	<h3><?php echo __( 'Mentions', 'semantic-linkbacks' ); ?></h3>
+	<?php
+	list_linkbacks(
+		array(
+			'li-class' => array( 'single-mention', 'p-mention' ),
+		),
+		get_linkbacks( 'mention' )
+	);
+	?>
 </div>
 <?php endif; ?>


### PR DESCRIPTION
mentions generally always have meaningful content, and we have good logic for rendering that full content when it's short enough, and excerpts otherwise. so, i'd argue that they should always be rendered, and not facepiled.

cc @dshanske. happy to discuss more if you all disagree!

fixes #114