### PR TITLE
facepiles: make sure avatars are always visible images

### DIFF
--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -527,7 +527,7 @@ class Linkbacks_Handler {
 		$mystery = get_avatar_url( NULL, array(
 			'default' => ( $def == 'blank' ? 'mystery' : $def )
 		) );
-		$avatar = str_replace('<img ', '<img onerror="this.src=\'' . $mystery . '\'; this.srcset = \'\'" ', $avatar);
+		$avatar = str_replace('<img ', '<img onerror="this.src=\'' . $mystery . '\'; this.srcset = \'\'; this.onerror = null" ', $avatar);
 
 		return $avatar;
 	}

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -51,7 +51,7 @@ class Linkbacks_Handler {
 		add_action( 'edit_comment', array( 'Linkbacks_Handler', 'update_meta' ), 10, 2 );
 
 		add_filter( 'pre_get_avatar_data', array( 'Linkbacks_Handler', 'pre_get_avatar_data' ), 11, 5 );
-		add_filter( 'get_avatar' , array( 'Linkbacks_Handler', 'get_avatar' ), 1, 5 );
+		add_filter( 'get_facepile_avatar' , array( 'Linkbacks_Handler', 'get_facepile_avatar' ), 10, 1 );
 		// To extend or to override the default behavior, just use the `comment_text` filter with a lower
 		// priority (so that it's called after this one) or remove the filters completely in
 		// your code: `remove_filter('comment_text', array('Linkbacks_Handler', 'comment_text_add_cite'), 11);`
@@ -509,27 +509,23 @@ class Linkbacks_Handler {
 	}
 
 	/**
-	 * Ensures avatar images are visible.
-	 *
-	 * If the default avatar setting is 'blank', switch to a visible
-	 * placeholder, TODO since this is a facepile.
+	 * Ensure facepile avatar images are visible.
 	 *
 	 * Also inject a JS fallback to a visible placeholder image, since
 	 * webmention author images are usually remote, and can disappear over time.
 	 *
-	 * @param array             $args Arguments passed to get_avatar_data(), after processing.
-	 * @param int|string|object $id_or_email A user ID, email address, or comment object
+	 * @param string $avatar <img> tag for avatar
 	 *
-	 * @return array $args
+	 * @return string $avatar
 	 */
-	public static function get_avatar( $avatar, $id_or_email, $size, $default, $alt ) {
-		if ( strpos( $avatar, 'gravatar.com/' ) != FALSE ) {
+	public static function get_facepile_avatar( $avatar ) {
+		if ( strpos( $avatar, 'gravatar.com/' ) != false ) {
 			$avatar = str_replace( 'd=blank', 'd=mm', $avatar );
 		}
 
-		$default = get_option( 'avatar_default' );
+		$def = get_option( 'avatar_default' );
 		$mystery = get_avatar_url( NULL, array(
-			'default' => ( $default == 'blank' ? 'mystery' : $default )
+			'default' => ( $def == 'blank' ? 'mystery' : $def )
 		) );
 		$avatar = str_replace('<img ', '<img onerror="this.src=\'' . $mystery . '\'; this.srcset = \'\'" ', $avatar);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -139,6 +139,13 @@ function list_linkbacks( $args, $comments ) {
 			<span id="mentions-below-fold" style="display: none">';
 		}
 
+		/**
+		 * Filters the avatar <img> tag displayed in a facepile.
+		 *
+		 * @param string $avatar HTML string with <img> tag
+		 */
+		$avatar = apply_filters( 'get_facepile_avatar', get_avatar( $comment, $r['avatar_size']) );
+
 		$return .= sprintf( '<li class="%1$s" id="%5$s">
 				<span class="p-author h-card">
 					<a class="u-url" title="%6$s" href="%3$s">%2$s</a>
@@ -147,7 +154,7 @@ function list_linkbacks( $args, $comments ) {
 				<a class="u-url" href="%7$s"></a>
 			</li>',
 			$classes,
-			get_avatar( $comment, $r['avatar_size'] ),
+			$avatar,
 			get_comment_author_url( $comment ),
 			get_comment_author( $comment ),
 			esc_attr( 'comment-' . $comment->comment_ID ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -139,22 +139,6 @@ function list_linkbacks( $args, $comments ) {
 			<span id="mentions-below-fold" style="display: none">';
 		}
 
-		// Avatar image for comment author.
-		//
-		// If the default avatar setting is 'blank', switch it to a visible
-		// placeholder, since this is a facepile. Also inject a JS fallback to a
-		// visible placeholder image, since webmention author images are usually
-		// remote, and can disappear over time.
-		$avatar = get_avatar( $comment, $r['avatar_size'] );
-		if ( strpos( $avatar, 'gravatar.com/' ) != FALSE ) {
-			$avatar = str_replace( 'd=blank', 'd=mm', $avatar );
-		}
-		$default = get_option( 'avatar_default' );
-		$mystery = get_avatar_url( NULL, array(
-			'default' => ( $default == 'blank' ? 'mystery' : $default )
-		) );
-		$avatar = str_replace('<img ', '<img onerror="this.src=\'' . $mystery . '\'; this.srcset = \'\'" ', $avatar);
-
 		$return .= sprintf( '<li class="%1$s" id="%5$s">
 				<span class="p-author h-card">
 					<a class="u-url" title="%6$s" href="%3$s">%2$s</a>
@@ -163,7 +147,7 @@ function list_linkbacks( $args, $comments ) {
 				<a class="u-url" href="%7$s"></a>
 			</li>',
 			$classes,
-			$avatar,
+			get_avatar( $comment, $r['avatar_size'] ),
 			get_comment_author_url( $comment ),
 			get_comment_author( $comment ),
 			esc_attr( 'comment-' . $comment->comment_ID ),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -126,6 +126,7 @@ function list_linkbacks( $args, $comments ) {
 	$classes = join( ' ', $classes );
 	$return = sprintf( '<%1$s class="%2$s">', $r['style'], $r['style-class'] );
 	$fold_at = get_option( 'semantic_linkbacks_facepiles_fold_limit', 8 );
+
 	foreach ( $comments as $i => $comment ) {
 		if ( $fold_at && $i == $fold_at ) {
 			$return .= '<li class="single-mention mention-ellipsis">
@@ -138,6 +139,22 @@ function list_linkbacks( $args, $comments ) {
 			<span id="mentions-below-fold" style="display: none">';
 		}
 
+		// Avatar image for comment author.
+		//
+		// If the default avatar setting is 'blank', switch it to a visible
+		// placeholder, since this is a facepile. Also inject a JS fallback to a
+		// visible placeholder image, since webmention author images are usually
+		// remote, and can disappear over time.
+		$avatar = get_avatar( $comment, $r['avatar_size'] );
+		if ( strpos( $avatar, 'gravatar.com/' ) != FALSE ) {
+			$avatar = str_replace( 'd=blank', 'd=mm', $avatar );
+		}
+		$default = get_option( 'avatar_default' );
+		$mystery = get_avatar_url( NULL, array(
+			'default' => ( $default == 'blank' ? 'mystery' : $default )
+		) );
+		$avatar = str_replace('<img ', '<img onerror="this.src=\'' . $mystery . '\'; this.srcset = \'\'" ', $avatar);
+
 		$return .= sprintf( '<li class="%1$s" id="%5$s">
 				<span class="p-author h-card">
 					<a class="u-url" title="%6$s" href="%3$s">%2$s</a>
@@ -146,7 +163,7 @@ function list_linkbacks( $args, $comments ) {
 				<a class="u-url" href="%7$s"></a>
 			</li>',
 			$classes,
-			get_avatar( $comment, $r['avatar_size'] ),
+			$avatar,
 			get_comment_author_url( $comment ),
 			get_comment_author( $comment ),
 			esc_attr( 'comment-' . $comment->comment_ID ),

--- a/tests/test-rendering.php
+++ b/tests/test-rendering.php
@@ -25,7 +25,7 @@ class RenderingTest extends WP_UnitTestCase {
 		$comments = $this->make_comments(1);
 		$this->assertStringMatchesFormat( '<ul class="mention-list"><li class="single-mention h-cite" id="comment-2">
 				<span class="p-author h-card">
-					<a class="u-url" title="Person 0 liked this Article on example.com." href="http://example.com/person0"><img onerror="this.src=\'http://%c.gravatar.com/avatar/?s=96&d=mm&r=g\'; this.srcset = \'\'" alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' /></a>
+					<a class="u-url" title="Person 0 liked this Article on example.com." href="http://example.com/person0"><img onerror="this.src=\'http://%c.gravatar.com/avatar/?s=96&d=mm&r=g\'; this.srcset = \'\'; this.onerror = null" alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' /></a>
 					<span class="hide-name p-name">Person 0</span>
 				</span>
 				<a class="u-url" href=""></a>

--- a/tests/test-rendering.php
+++ b/tests/test-rendering.php
@@ -23,13 +23,28 @@ class RenderingTest extends WP_UnitTestCase {
 
 	public function test_facepile_markup() {
 		$comments = $this->make_comments(1);
-		$this->assertEquals( '<ul class="mention-list"><li class="single-mention h-cite" id="comment-2">
+		$this->assertStringMatchesFormat( '<ul class="mention-list"><li class="single-mention h-cite" id="comment-2">
 				<span class="p-author h-card">
-					<a class="u-url" title="Person 0 liked this Article on example.com." href="http://example.com/person0"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' /></a>
+					<a class="u-url" title="Person 0 liked this Article on example.com." href="http://example.com/person0"><img onerror="this.src=\'http://%c.gravatar.com/avatar/?s=96&d=mm&r=g\'; this.srcset = \'\'" alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' /></a>
 					<span class="hide-name p-name">Person 0</span>
 				</span>
 				<a class="u-url" href=""></a>
 			</li></ul>', list_linkbacks( array( 'echo' => false ), $comments ) );
+	}
+
+	public function test_facepile_converts_default_gravatar_to_mystery_man() {
+		update_option( 'avatar_default', 'blank' );
+
+		$comment = get_comment( wp_new_comment( array(
+			'comment_author_url' => 'http://example.com/person',
+			'comment_author' => 'Person',
+			'comment_type' => 'webmention',
+		) ) );
+		$this->assertContains( 'gravatar.com/avatar/?s=96&d=blank', get_avatar_url( $comment ) );
+
+		$html = list_linkbacks( array( 'echo' => false ), array( $comment ) );
+		$this->assertContains( 'gravatar.com/avatar/?s=96&d=mm', $html );
+		$this->assertFalse( strpos( $html, 'gravatar.com/avatar/?s=96&d=blank' ) );
 	}
 
 	public function test_facepile_fold() {


### PR DESCRIPTION
fixes #116

If the WordPress default avatar setting is `blank`, switch it to a visible placeholder, since this is a facepile. Also inject a JS fallback to a visible placeholder image, since webmention author images are usually remote, and can disappear over time.

screenshot:

<img width="618" alt="image" src="https://user-images.githubusercontent.com/778068/32751509-0977f55c-c87b-11e7-8768-f9e341379b03.png">
