### PR TITLE
Comment Walker Enhancements

### DIFF
--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -25,7 +25,7 @@ class Linkbacks_Handler {
 		// To extend or to override the default behavior, just use the `comment_text` filter with a lower
 		// priority (so that it's called after this one) or remove the filters completely in
 		// your code: `remove_filter('comment_text', array('Linkbacks_Handler', 'comment_text_add_cite'), 11);`
-		add_filter( 'comment_text', array( 'Linkbacks_Handler', 'comment_text_add_cite' ), 11, 3 );
+		// add_filter( 'comment_text', array( 'Linkbacks_Handler', 'comment_text_add_cite' ), 11, 3 );
 		add_filter( 'comment_text', array( 'Linkbacks_Handler', 'comment_text_excerpt' ), 12, 3 );
 		add_filter( 'comment_excerpt', array( 'Linkbacks_Handler', 'comment_text_excerpt' ), 5, 2 );
 

--- a/includes/class-linkbacks-walker-comment.php
+++ b/includes/class-linkbacks-walker-comment.php
@@ -16,7 +16,7 @@ class Semantic_Linkbacks_Walker_Comment extends Walker_Comment {
 			return true;
 		}
 
-		if ( $comment->type && 'comment' != $comment_type ) {
+		if ( 'comment' !== get_comment_type( $comment ) ) {
 			$type = 'mention';
 		} else {
 			$type = Linkbacks_Handler::get_type( $comment );
@@ -31,6 +31,29 @@ class Semantic_Linkbacks_Walker_Comment extends Walker_Comment {
 		$option = 'semantic_linkbacks_facepile_' . $type;
 
 		return $type && 'reply' != $type && get_option( $option, true );
+	}
+
+	static function get_comment_author_link( $comment_ID = 0 ) {
+    		$comment = get_comment( $comment_ID );
+		$url     = get_comment_author_url( $comment );
+		$author  = get_comment_author( $comment );
+ 
+		if ( empty( $url ) || 'http://' == $url )
+			$return = "<span class='p-name'>" . $author . "</span>";
+		else
+			$return = "<a href='$url' rel='external nofollow' class='u-url p-name'>$author</a>";
+		
+		/**
+		 * Filters the comment author's link for display.
+		 *
+		 * @since 1.5.0
+		 * @since 4.1.0 The `$author` and `$comment_ID` parameters were added
+		 * @param string $return     The HTML-formatted comment author link.
+		 *                           Empty for an invalid URL.
+		 * @param string $author     The comment author's username.
+		 * @param int    $comment_ID The comment ID.
+		 */
+		return apply_filters( 'get_comment_author_link', $return, $author, $comment->comment_ID );
 	}
 
 	static function is_reaction( $comment ) {
@@ -53,4 +76,64 @@ class Semantic_Linkbacks_Walker_Comment extends Walker_Comment {
 			return parent::end_el( $output, $comment, $depth, $args );
 		}
 	}
+
+	protected function html5_comment( $comment, $depth, $args ) {
+		$tag = ( 'div' === $args['style'] ) ? 'div' : 'li';
+		$type = Linkbacks_Handler::get_type( $comment );
+		$url = Linkbacks_Handler::get_url( $comment );
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		// strip leading www, if any
+		$host = preg_replace( '/^www\./', '', $host );
+
+?>
+		<<?php echo $tag; ?> id="comment-<?php comment_ID(); ?>" <?php comment_class( $this->has_children ? 'parent' : '', $comment ); ?>>
+			<article id="div-comment-<?php comment_ID(); ?>" class="comment-body">
+				<footer class="comment-meta">
+					<div class="comment-author vcard h-card u-author">
+						<?php if ( 0 != $args['avatar_size'] ) echo get_avatar( $comment, $args['avatar_size'] ); ?>
+						<?php
+							/* translators: %s: comment author link */
+							printf( __( '%s <span class="says">says:</span>' ),
+								sprintf( '<b>%s</b>', self::get_comment_author_link( $comment ) )
+							);
+							if ( $type ) {
+								echo '<small>&nbsp;@&nbsp;<cite><a href="' . $url . '">' . $host . '</a></cite></small>';
+							}
+						?>
+					</div><!-- .comment-author -->
+
+					<div class="comment-metadata">
+						<a class="u-url" href="<?php echo esc_url( get_comment_link( $comment, $args ) ); ?>">
+							<time class="dt-published" datetime="<?php comment_time( DATE_W3C ); ?>">
+								<?php
+									/* translators: 1: comment date, 2: comment time */
+									printf( __( '%1$s at %2$s' ), get_comment_date( '', $comment ), get_comment_time() );
+								?>
+							</time>
+						</a>
+						<?php edit_comment_link( __( 'Edit' ), '<span class="edit-link">', '</span>' ); ?>
+					</div><!-- .comment-metadata -->
+
+					<?php if ( '0' == $comment->comment_approved ) : ?>
+					<p class="comment-awaiting-moderation"><?php _e( 'Your comment is awaiting moderation.' ); ?></p>
+					<?php endif; ?>
+				</footer><!-- .comment-meta -->
+
+				<div class="comment-content e-content p-name">
+					<?php comment_text(); ?>
+				</div><!-- .comment-content -->
+
+				<?php
+				comment_reply_link( array_merge( $args, array(
+					'add_below' => 'div-comment',
+					'depth'     => $depth,
+					'max_depth' => $args['max_depth'],
+					'before'    => '<div class="reply">',
+					'after'     => '</div>'
+				) ) );
+				?>
+			</article><!-- .comment-body -->
+<?php
+	}
+
 }

--- a/includes/class-linkbacks-walker-comment.php
+++ b/includes/class-linkbacks-walker-comment.php
@@ -50,7 +50,7 @@ class Semantic_Linkbacks_Walker_Comment extends Walker_Comment {
 
 	function end_el( &$output, $comment, $depth = 0, $args = array() ) {
 		if ( ! self::should_facepile( $comment ) ) {
-			return parent::end_el( $output, $comment, $depth, $args, $id );
+			return parent::end_el( $output, $comment, $depth, $args );
 		}
 	}
 }


### PR DESCRIPTION
This fixes a persistent error and adds in support for Semantic Linkbacks into comments. As long as we are adding a comment walker, this marks up the comment with microformats and moves the citation from comment text up to next to the name for a cleaner look.

I had something similar in my comment walker that I used in my themes and my old facepiles plugin, but this comment walker disabled that, so I think it is time to merge the two.