### PR TITLE
Comment Class Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ The Webmention and Pingback logos are made by [Aaron Parecki](http://aaronpareck
 
 Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks](https://github.com/pfefferle/wordpress-semantic-linkbacks). Please file support issues there.
 
+### 3.7.3 ###
+* Remove `h-as` properties
+* Remove hard-coded microformats2 properties from facepile and move them to being generated from comment_class
+* Remove unused properties
+* Introduce type argument in list_linkbacks to generate unique ideas for each list of linkbacks without having to specify them using style and li-class
+
 ### 3.7.2 ###
 
 * Bugfix: "Normal comments" hidden in comment-section (https://github.com/pfefferle/wordpress-semantic-linkbacks/issues/140)

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -561,19 +561,19 @@ class Linkbacks_Handler {
 		$comment = get_comment( $comment_id );
 		// "comment type to class" mapper
 		$class_mapping = array(
-			'mention'       => array( 'p-mention' ),
+			'mention'       => array( 'u-mention' ),
 
-			'reply'         => array( 'p-reply', 'u-comment' ),
-			'repost'        => array( 'p-repost' ),
-			'like'          => array( 'p-like' ),
-			'favorite'      => array( 'p-favorite' ),
-			'tag'           => array( 'p-tag' ),
-			'bookmark'      => array( 'p-bookmark' ),
-			'rsvp:yes'      => array( 'p-rsvp' ),
-			'rsvp:no'       => array( 'p-rsvp' ),
-			'rsvp:maybe'    => array( 'p-rsvp' ),
-			'rsvp:invited'  => array( 'p-rsvp' ),
-			'rsvp:tracking' => array( 'p-rsvp' ),
+			'reply'         => array( 'u-comment' ),
+			'repost'        => array( 'u-repost' ),
+			'like'          => array( 'u-like' ),
+			'favorite'      => array( 'u-favorite' ),
+			'tag'           => array( 'u-tag' ),
+			'bookmark'      => array( 'u-bookmark' ),
+			'rsvp:yes'      => array( 'u-rsvp' ),
+			'rsvp:no'       => array( 'u-rsvp' ),
+			'rsvp:maybe'    => array( 'u-rsvp' ),
+			'rsvp:invited'  => array( 'u-rsvp' ),
+			'rsvp:tracking' => array( 'u-rsvp' ),
 		);
 
 		$semantic_linkbacks_type = self::get_type( $comment );
@@ -581,10 +581,9 @@ class Linkbacks_Handler {
 		// check the comment type
 		if ( $semantic_linkbacks_type && isset( $class_mapping[ $semantic_linkbacks_type ] ) ) {
 			$classes = array_merge( $classes, $class_mapping[ $semantic_linkbacks_type ] );
-			$classes[] = 'h-cite';
 			$classes = array_unique( $classes );
 		}
-
+		$classes[] = 'h-cite';
 		return $classes;
 	}
 

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -559,22 +559,21 @@ class Linkbacks_Handler {
 	public static function comment_class( $classes, $class, $comment_id, $post_id ) {
 		// get comment
 		$comment = get_comment( $comment_id );
-
 		// "comment type to class" mapper
 		$class_mapping = array(
-			'mention'       => array( 'h-as-mention' ),
+			'mention'       => array( 'p-mention' ),
 
-			'reply'         => array( 'h-as-reply' ),
-			'repost'        => array( 'h-as-repost', 'p-repost' ),
-			'like'          => array( 'h-as-like', 'p-like' ),
-			'favorite'      => array( 'h-as-favorite', 'p-favorite' ),
-			'tag'           => array( 'h-as-tag', 'p-tag' ),
-			'bookmark'      => array( 'h-as-bookmark', 'p-bookmark' ),
-			'rsvp:yes'      => array( 'h-as-rsvp' ),
-			'rsvp:no'       => array( 'h-as-rsvp' ),
-			'rsvp:maybe'    => array( 'h-as-rsvp' ),
-			'rsvp:invited'  => array( 'h-as-rsvp' ),
-			'rsvp:tracking' => array( 'h-as-rsvp' ),
+			'reply'         => array( 'p-reply', 'u-comment' ),
+			'repost'        => array( 'p-repost' ),
+			'like'          => array( 'p-like' ),
+			'favorite'      => array( 'p-favorite' ),
+			'tag'           => array( 'p-tag' ),
+			'bookmark'      => array( 'p-bookmark' ),
+			'rsvp:yes'      => array( 'p-rsvp' ),
+			'rsvp:no'       => array( 'p-rsvp' ),
+			'rsvp:maybe'    => array( 'p-rsvp' ),
+			'rsvp:invited'  => array( 'p-rsvp' ),
+			'rsvp:tracking' => array( 'p-rsvp' ),
 		);
 
 		$semantic_linkbacks_type = self::get_type( $comment );
@@ -582,7 +581,7 @@ class Linkbacks_Handler {
 		// check the comment type
 		if ( $semantic_linkbacks_type && isset( $class_mapping[ $semantic_linkbacks_type ] ) ) {
 			$classes = array_merge( $classes, $class_mapping[ $semantic_linkbacks_type ] );
-
+			$classes[] = 'h-cite';
 			$classes = array_unique( $classes );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -68,6 +68,12 @@ The Webmention and Pingback logos are made by [Aaron Parecki](http://aaronpareck
 
 Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks](https://github.com/pfefferle/wordpress-semantic-linkbacks). Please file support issues there.
 
+= 3.7.3 =
+* Remove `h-as` properties
+* Remove hard-coded microformats2 properties from facepile and move them to being generated from comment_class
+* Remove unused properties
+* Introduce type argument in list_linkbacks to generate unique ideas for each list of linkbacks without having to specify them using style and li-class
+
 = 3.7.2 =
 
 * Bugfix: "Normal comments" hidden in comment-section (https://github.com/pfefferle/wordpress-semantic-linkbacks/issues/140)

--- a/templates/linkbacks.php
+++ b/templates/linkbacks.php
@@ -4,7 +4,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array( 'single-mention', 'p-reply', 'emoji-reaction' ),
+			'type' => 'reacji',
 		),
 		Semantic_Linkbacks_Walker_Comment::$reactions
 	);
@@ -18,7 +18,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array( 'single-mention', 'p-like' ),
+			'type' => 'like',
 		),
 		get_linkbacks( 'like' )
 	);
@@ -32,7 +32,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array( 'single-mention', 'p-favorite' ),
+			'type' => 'favorite',
 		),
 		get_linkbacks( 'favorite' )
 	);
@@ -46,7 +46,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array( 'single-mention', 'p-bookmark' ),
+			'type' => 'bookmark',
 		),
 		get_linkbacks( 'bookmark' )
 	);
@@ -60,7 +60,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array( 'single-mention', 'p-repost' ),
+			'type' => 'repost',
 		),
 		get_linkbacks( 'repost' )
 	);
@@ -74,7 +74,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array( 'single-mention', 'p-tag' ),
+			'type' => 'tag',
 		),
 		get_linkbacks( 'tag' )
 	);
@@ -91,10 +91,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array(
-				'single-mention',
-				'p-rsvp',
-			)
+			'tag',
 		),
 		get_linkbacks( 'rsvp:yes' )
 	);
@@ -106,10 +103,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array(
-				'single-mention',
-				'p-rsvp',
-			)
+			'type' => 'invited',
 		),
 		get_linkbacks( 'rsvp:invited' )
 	);
@@ -121,10 +115,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array(
-				'single-mention',
-				'p-rsvp',
-			)
+			'type' => 'rsvp-maybe',
 		),
 		get_linkbacks( 'rsvp:maybe' )
 	);
@@ -136,10 +127,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array(
-				'single-mention',
-				'p-rsvp',
-			)
+			'type' => 'rsvp-no',
 		),
 		get_linkbacks( 'rsvp:no' )
 	);
@@ -151,10 +139,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array(
-				'single-mention',
-				'p-rsvp',
-			)
+			'type' => 'rsvp-tracking',
 		),
 		get_linkbacks( 'rsvp:tracking' )
 	);
@@ -169,7 +154,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'li-class' => array( 'single-mention', 'p-mention' ),
+			'type' => 'mention',
 		),
 		get_linkbacks( 'mention' )
 	);

--- a/templates/linkbacks.php
+++ b/templates/linkbacks.php
@@ -91,7 +91,7 @@
 	<?php
 	list_linkbacks(
 		array(
-			'tag',
+			'type' => 'rsvp-yes',
 		),
 		get_linkbacks( 'rsvp:yes' )
 	);

--- a/tests/test-rendering.php
+++ b/tests/test-rendering.php
@@ -30,7 +30,7 @@ class RenderingTest extends WP_UnitTestCase {
 	public function test_facepile_markup() {
 		$comments = $this->make_comments( 1 );
 		$this->assertStringMatchesFormat(
-			'<ul class="mention-list"><li class="single-mention h-cite" id="comment-2">
+			'<ul class="mention-list linkback-mention"><li class="webmention even thread-even depth-1 linkback-mention-single u-like h-cite" id="comment-2">
 				<span class="p-author h-card">
 					<a class="u-url" title="Person 0 liked this Article on example.com." href="http://example.com/person0"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' /> </a>
 					<span class="hide-name p-name">Person 0</span>
@@ -105,7 +105,7 @@ class RenderingTest extends WP_UnitTestCase {
 		$this->assertStringMatchesFormat(
 			'<div class="reactions">
 	<h3>Reacjis</h3>
-	<ul class="mention-list"><li class="single-mention p-reply emoji-reaction h-cite" id="comment-%d">
+	<ul class="mention-list linkback-reacji"><li class="comment even thread-even depth-1 linkback-reacji-single h-cite" id="comment-%d">
 				<span class="p-author h-card">
 					<a class="u-url" title="Person 😢 on example.com." href="http://example.com/person"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' /> <span class="emoji-overlay">😢</span></a>
 					<span class="hide-name p-name">Person</span>


### PR DESCRIPTION
* Removes h-as properties
* Addresses fact that list_linkbacks was not using comment_class filter
* Introduces type argument in list_linkbacks that allows a list and single element class to be generated by default.
* Remove unused properties