### PR TITLE
Add Swarm Coins property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks]
 * Remove hard-coded microformats2 properties from facepile and move them to being generated from comment_class
 * Remove unused properties
 * Introduce type argument in list_linkbacks to generate unique ideas for each list of linkbacks without having to specify them using style and li-class
+* Whitelist property swarm-coins, used by [OwnYourSwarm](https://ownyourswarm.p3k.io/docs#coins) and display it if using built-in comment handler.
 
 ### 3.7.2 ###
 

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -327,11 +327,33 @@ class Linkbacks_Handler {
 	 * @return string the type
 	 */
 	public static function get_type( $comment ) {
-		if ( is_numeric( $comment ) ) {
-			$comment = get_comment( $comment );
+		if ( $comment instanceof WP_Comment ) {
+			$comment = $comment->comment_ID;
 		}
 		// get type...
-		return get_comment_meta( $comment->comment_ID, 'semantic_linkbacks_type', true );
+		return get_comment_meta( $comment, 'semantic_linkbacks_type', true );
+	}
+
+	/**
+	 * Return property
+	 *
+	 * @param int|WP_Comment $comment Comment
+	 * @param string $key Key
+	 *
+	 * @return boolean|string|array Property or False if Property Does Not Exist
+	 */
+	public static function get_prop( $comment, $key ) {
+		if ( $comment instanceof WP_Comment ) {
+			$comment = $comment->comment_ID;
+		}
+		$prop = get_comment_meta( $comment, $key );
+		if ( ! $prop || is_string( $prop ) ) {
+			return $prop;
+		}
+		if ( 1 === count( $prop ) ) {
+			return array_shift( $prop );
+		}
+		return $prop;
 	}
 
 
@@ -343,11 +365,11 @@ class Linkbacks_Handler {
 	 * @return string the URL
 	 */
 	public static function get_author_url( $comment ) {
-		if ( is_numeric( $comment ) ) {
-			$comment = get_comment( $comment );
+		if ( $comment instanceof WP_Comment ) {
+			$comment = $comment->comment_ID;
 		}
 		// get author URL...
-		return get_comment_meta( $comment->comment_ID, 'semantic_linkbacks_author_url', true );
+		return get_comment_meta( $comment, 'semantic_linkbacks_author_url', true );
 	}
 
 	/**

--- a/includes/class-linkbacks-mf2-handler.php
+++ b/includes/class-linkbacks-mf2-handler.php
@@ -257,6 +257,7 @@ class Linkbacks_MF2_Handler {
 			'audio',
 			'photo',
 			'featured',
+			'swarm-coins' // https://ownyourswarm.p3k.io/docs#coins
 		);
 
 		// Add in supported properties

--- a/includes/class-linkbacks-walker-comment.php
+++ b/includes/class-linkbacks-walker-comment.php
@@ -76,11 +76,12 @@ class Semantic_Linkbacks_Walker_Comment extends Walker_Comment {
 			parent::html5_comment( $comment, $depth, $args );
 			return;
 		}
-		$tag  = ( 'div' === $args['style'] ) ? 'div' : 'li';
-		$cite = apply_filters( 'semantic_linkbacks_cite', '<small>&nbsp;@&nbsp;<cite><a href="%1s">%2s</a></cite></small>' );
-		$type = Linkbacks_Handler::get_type( $comment );
-		$url  = Linkbacks_Handler::get_url( $comment );
-		$host = wp_parse_url( $url, PHP_URL_HOST );
+		$tag   = ( 'div' === $args['style'] ) ? 'div' : 'li';
+		$cite  = apply_filters( 'semantic_linkbacks_cite', '<small>&nbsp;@&nbsp;<cite><a href="%1s">%2s</a></cite></small>' );
+		$type  = Linkbacks_Handler::get_type( $comment );
+		$url   = Linkbacks_Handler::get_url( $comment );
+		$coins = Linkbacks_Handler::get_prop( $comment, 'mf2_swarm-coins' );
+		$host  = wp_parse_url( $url, PHP_URL_HOST );
 		// strip leading www, if any
 		$host = preg_replace( '/^www\./', '', $host );
 
@@ -103,10 +104,21 @@ class Semantic_Linkbacks_Walker_Comment extends Walker_Comment {
 						if ( $type && ! empty( $cite ) ) {
 							printf( $cite, $url, $host );
 						}
+
 						?>
 					</div><!-- .comment-author -->
 
 					<div class="comment-metadata">
+					<?php
+						if ( $coins ) {
+							// translators: Number of Swarm Coins
+							printf( _n( '+%d coin', '+%d coins', (int) $coins, 'semantic-linkbacks' ), $coins );
+							echo ' / ';
+						}
+					?>
+
+
+
 						<a class="u-url" href="<?php echo esc_url( get_comment_link( $comment, $args ) ); ?>">
 							<time class="dt-published" datetime="<?php comment_time( DATE_W3C ); ?>">
 								<?php

--- a/languages/semantic-linkbacks.pot
+++ b/languages/semantic-linkbacks.pot
@@ -2,17 +2,17 @@
 # This file is distributed under the MIT.
 msgid ""
 msgstr ""
-"Project-Id-Version: Semantic-Linkbacks 3.7.1\n"
+"Project-Id-Version: Semantic-Linkbacks 3.7.2\n"
 "Report-Msgid-Bugs-To: "
-"https://wordpress.org/support/plugin/semantic-linkbacks\n"
-"POT-Creation-Date: 2017-12-05 21:30:18+00:00\n"
+"http://wordpress.org/support/plugin/semantic-linkbacks\n"
+"POT-Creation-Date: 2017-12-29 09:07:37+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "PO-Revision-Date: 2017-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"X-Generator: grunt-wp-i18n 0.5.4\n"
+"X-Generator: grunt-wp-i18n 0.4.9\n"
 
 #: includes/class-linkbacks-handler.php:204
 #. translators: Name verb on domain
@@ -150,21 +150,28 @@ msgstr ""
 msgid "this Audio"
 msgstr ""
 
-#: includes/class-linkbacks-walker-comment.php:104
+#: includes/class-linkbacks-walker-comment.php:101
 #. translators: %s: comment author link
 msgid "%s <span class=\"says\">says:</span>"
 msgstr ""
 
-#: includes/class-linkbacks-walker-comment.php:118
+#: includes/class-linkbacks-walker-comment.php:115
+#. translators: Number of Swarm Coins
+msgid "+%d coin"
+msgid_plural "+%d coins"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/class-linkbacks-walker-comment.php:126
 #. translators: 1: comment date, 2: comment time
 msgid "%1$s at %2$s"
 msgstr ""
 
-#: includes/class-linkbacks-walker-comment.php:122
+#: includes/class-linkbacks-walker-comment.php:130
 msgid "Edit"
 msgstr ""
 
-#: includes/class-linkbacks-walker-comment.php:126
+#: includes/class-linkbacks-walker-comment.php:134
 msgid "Your response is awaiting moderation."
 msgstr ""
 
@@ -214,7 +221,7 @@ msgid ""
 "for:"
 msgstr ""
 
-#: templates/discussion-settings.php:7 templates/linkbacks.php:168
+#: templates/discussion-settings.php:7 templates/linkbacks.php:153
 msgid "Mentions"
 msgstr ""
 
@@ -262,19 +269,19 @@ msgstr ""
 msgid "Yes"
 msgstr ""
 
-#: templates/linkbacks.php:105
+#: templates/linkbacks.php:102
 msgid "Invited"
 msgstr ""
 
-#: templates/linkbacks.php:120
+#: templates/linkbacks.php:114
 msgid "Maybe"
 msgstr ""
 
-#: templates/linkbacks.php:135
+#: templates/linkbacks.php:126
 msgid "No"
 msgstr ""
 
-#: templates/linkbacks.php:150
+#: templates/linkbacks.php:138
 msgid "Tracking"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -73,6 +73,7 @@ Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks]
 * Remove hard-coded microformats2 properties from facepile and move them to being generated from comment_class
 * Remove unused properties
 * Introduce type argument in list_linkbacks to generate unique ideas for each list of linkbacks without having to specify them using style and li-class
+* Whitelist property swarm-coins, used by [OwnYourSwarm](https://ownyourswarm.p3k.io/docs#coins) and display it if using built-in comment handler.
 
 = 3.7.2 =
 


### PR DESCRIPTION
This adds in the storage of Swarm Coins(https://ownyourswarm.p3k.io/docs#coins). A lot of people seem to be using OwnYourSwarm, and keep filing issues regarding it with various plugins I'm involved with.

It also adds a helper function, get_prop, to Linkbacks_Handler. This is just a simple wrapper around get_comment_meta that allows the $comment object to be passed in and also returns single properties if stored as strings.

When adding it, I noticed that these wrapper functions were retrieving the comment object when not strictly needed, so made a slight optimization.