### PR TITLE
Enhance Post Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks]
 
 ### 3.7.4 ###
 * Replace `rsvp-invite` property which is not in use with `invite` property and add unit tests
+* Enhance post type returns to include post, page, and sitename
 
 ### 3.7.3 ###
 

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -419,25 +419,23 @@ class Linkbacks_Handler {
 	 * @return string the post type
 	 */
 	public static function get_post_type( $post_id ) {
-		$post_format = 'post';
-		if ( 'page' === get_post_type( $post_id ) ) {
-			$post_format = 'page';
-		}
-		if ( current_theme_supports( 'post-formats' ) ) {
-			$post_typestrings = self::get_post_type_strings();
+		$post_typestrings = self::get_post_type_strings();
+		$post_type = $post_typestrings[ 'post' ];
+		
+		// If this is the page homepages are redirected to then use the site name
+		if ( $post_id === get_option( 'webmention_home_mentions', 0 ) ) {
+			$post_type = get_bloginfo( 'name' );
+		} else if ( 'page' === get_post_type( $post_id ) ) {
+			$post_type = $post_typestrings[ 'page' ];
+		} else if ( current_theme_supports( 'post-formats' ) ) {
 			$post_format = get_post_format( $post_id );
 			
 			// add "standard" as default for post format enabled types
 			if ( ! $post_format || ! in_array( $post_format, array_keys( $post_typestrings ), true ) ) {
 				$post_format = 'standard';
 			}
-		}
-		
-		$post_type = $post_typestrings[ $post_format ];
-
-		// If this is the page homepages are redirected to then use the site name
-		if ( $post_id === get_option( 'webmention_home_mentions', 0 ) ) {
-			$post_type = get_bloginfo( 'name' );
+			
+			$post_type = $post_typestrings[ $post_format ];
 		}
 
 		return apply_filters( 'semantic_linkbacks_post_type', $post_type, $post_id );

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -431,7 +431,7 @@ class Linkbacks_Handler {
 			$post_format = get_post_format( $post_id );
 			
 			// add "standard" as default for post format enabled types
-			if ( ! $post_format || ! in_array( $post_format, array_keys( $post_typestrings ), true ) ) {
+			if ( ! $post_format || ! in_array( $post_format, array_keys( $post_typestrings ), true ) ) {
 				$post_format = 'standard';
 			}
 			

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -419,20 +419,21 @@ class Linkbacks_Handler {
 	 * @return string the post type
 	 */
 	public static function get_post_type( $post_id ) {
-		$post_typestrings = self::get_post_type_strings();
 		$post_format = 'post';
 		if ( 'page' === get_post_type( $post_id ) ) {
 			$post_format = 'page';
 		}
 		if ( current_theme_supports( 'post-formats' ) ) {
+			$post_typestrings = self::get_post_type_strings();
 			$post_format = get_post_format( $post_id );
+			
 			// add "standard" as default for post format enabled types
-			if ( ! $post_format || ! in_array( $post_format, array_keys( $post_typestrings ), true ) ) {
-				$post_format = 'standard';
+			if ( $post_format && in_array( $post_format, array_keys( $post_typestrings ), true ) ) {
+				$post_type = $post_typestrings[ $post_format ];
 			}
+			
+			$post_format = 'standard';
 		}
-
-		$post_type          = $post_typestrings[ $post_format ];
 
 		// If this is the page homepages are redirected to then use the site name
 		if ( $post_id === get_option( 'webmention_home_mentions', 0 ) ) {

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -419,20 +419,21 @@ class Linkbacks_Handler {
 	 * @return string the post type
 	 */
 	public static function get_post_type( $post_id ) {
-		$post_type = 'post';
+		$post_format = 'post';
 		if ( 'page' === get_post_type( $post_id ) ) {
-			$post_type = 'page';
+			$post_format = 'page';
 		}
 		if ( current_theme_supports( 'post-formats' ) ) {
 			$post_typestrings = self::get_post_type_strings();
 			$post_format = get_post_format( $post_id );
-			$post_type = 'standard';
 			
 			// add "standard" as default for post format enabled types
-			if ( $post_format && in_array( $post_format, array_keys( $post_typestrings ), true ) ) {
-				$post_type = $post_typestrings[ $post_format ];
+			if ( ! $post_format || ! in_array( $post_format, array_keys( $post_typestrings ), true ) ) {
+				$post_format = 'standard';
 			}
 		}
+		
+		$post_type = $post_typestrings[ $post_format ];
 
 		// If this is the page homepages are redirected to then use the site name
 		if ( $post_id === get_option( 'webmention_home_mentions', 0 ) ) {

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -421,18 +421,17 @@ class Linkbacks_Handler {
 	public static function get_post_type( $post_id ) {
 		$post_format = 'post';
 		if ( 'page' === get_post_type( $post_id ) ) {
-			$post_format = 'page';
+			$post_type = 'page';
 		}
 		if ( current_theme_supports( 'post-formats' ) ) {
 			$post_typestrings = self::get_post_type_strings();
 			$post_format = get_post_format( $post_id );
+			$post_type = 'standard';
 			
 			// add "standard" as default for post format enabled types
 			if ( $post_format && in_array( $post_format, array_keys( $post_typestrings ), true ) ) {
 				$post_type = $post_typestrings[ $post_format ];
 			}
-			
-			$post_format = 'standard';
 		}
 
 		// If this is the page homepages are redirected to then use the site name

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -419,7 +419,7 @@ class Linkbacks_Handler {
 	 * @return string the post type
 	 */
 	public static function get_post_type( $post_id ) {
-		$post_format = 'post';
+		$post_type = 'post';
 		if ( 'page' === get_post_type( $post_id ) ) {
 			$post_type = 'page';
 		}

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,7 @@ Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks]
 
 = 3.7.4 =
 * Replace `rsvp-invite` property which is not in use with `invite` property and add unit tests
+* Enhance post type returns to include post, page, and sitename
 
 = 3.7.3 =
 


### PR DESCRIPTION
This is an attempt to address the concerns of the previous PR separately from the person tag issue. It adds in a string for 'post' and 'page', which would be present on all sites. It also, if this is a homepage mention, will display the website name as opposed to the string. 

Alternatively, if the name doesn't work, I would go with 'this Site' as an alternative, but I think the sitename best represents intent of the mentioner.

Currently, when it is a custom post type, it will default to 'this post'. Considering the concern re language, it is best that the creator or user of the custom post type set this themselves.