### PR TITLE
Fix load issues with Webmention vs Semantic Linkbacks

### DIFF
--- a/semantic-linkbacks.php
+++ b/semantic-linkbacks.php
@@ -61,7 +61,7 @@ class Semantic_Linkbacks_Plugin {
 
 	public static function admin_init() {
 		self::privacy_declaration();
-		$page = class_exists( 'Webmention_Plugin' ) ? 'webmention' : 'discussion';
+		$page = function_exists( 'webmention_init' ) ? 'webmention' : 'discussion';
 		add_settings_section(
 			'semantic-linkbacks',
 			__( 'Semantic Linkbacks Settings', 'semantic-linkbacks' ),
@@ -99,7 +99,7 @@ class Semantic_Linkbacks_Plugin {
 	}
 
 	public static function register_settings() {
-		$option_group = class_exists( 'Webmention_Plugin' ) ? 'webmention' : 'discussion';
+		$option_group = function_exists( 'webmention_init' ) ? 'webmention' : 'discussion';
 		register_setting(
 			$option_group,
 			'semantic_linkbacks_facepiles',

--- a/semantic-linkbacks.php
+++ b/semantic-linkbacks.php
@@ -12,7 +12,7 @@
  * Requires PHP: 5.4
  */
 
-add_action( 'plugins_loaded', array( 'Semantic_Linkbacks_Plugin', 'init' ) );
+add_action( 'plugins_loaded', array( 'Semantic_Linkbacks_Plugin', 'init' ), 11 );
 
 // initialize admin settings
 add_action( 'admin_init', array( 'Semantic_Linkbacks_Plugin', 'admin_init' ) );


### PR DESCRIPTION
Address #231 and #236

It delays the load of Semantic Linkbacks till after Webmention has loaded so it will correctly disable the Avatar file inside Semantic Linkbacks. It was loading both files, loading to an issue.

It also fixes the broken webmention plugin check that is looking for the removed class.

Suggest we push this as soon as possible to fix the experience for all.