### PR TITLE
Some changes on feature to toggle additional facepiles

### DIFF
--- a/css/semantic-linkbacks.css
+++ b/css/semantic-linkbacks.css
@@ -14,7 +14,12 @@
 	display: none;
 }
 
-.mention-list .toggle-additional-facepiles {
+.mention-list.initialized .additional-facepile,
+.mention-list .additional-facepile-button-list-item {
+	display: none;
+}
+
+.mention-list.initialized .additional-facepile-button-list-item:not(.is-hidden) {
 	display: inline-block;
 	text-align: center;
 	height: 64px;
@@ -22,6 +27,16 @@
 	line-height: 1.5;
 	font-size: 32px;
 	cursor: pointer;
+}
+
+.mention-list.initialized .additional-facepile-button-list-item.is-hidden ~ .additional-facepile {
+	display: inline-block;
+}
+
+.mention-list .additional-facepile-button-list-item button {
+	border: none;
+	background-color: transparent;
+	padding: 0;
 }
 
 .mention-list li img {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -259,7 +259,7 @@ function list_linkbacks( $args, $comments ) {
 		$return .= sprintf(
 			'<li class="additional-facepile-button-list-item is-hidden"><button class="hide-additional-facepiles"><span aria-hidden="true">&hellip;</span><span class="screen-reader-text">%s</span></button></li>',
 			sprintf( /* translators: s=Linback type */
-				__( 'Hide more %s'),
+				__( 'Show fewer %s'),
 				$type_labels[$r['type']]
 			)
 		);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -208,7 +208,7 @@ function list_linkbacks( $args, $comments ) {
 			$return .= sprintf(
 				'<li class="additional-facepile-button-list-item"><button class="show-additional-facepiles"><span aria-hidden="true">&hellip;</span><span class="screen-reader-text">%s</span></button></li>',
 				sprintf( /* translators: s=Linback type */
-					__( 'Show more %s'),
+					__( 'Show more %s', 'semantic-linkbacks' ),
 					$type_labels[$r['type']]
 				)
 			);
@@ -259,7 +259,7 @@ function list_linkbacks( $args, $comments ) {
 		$return .= sprintf(
 			'<li class="additional-facepile-button-list-item is-hidden"><button class="hide-additional-facepiles"><span aria-hidden="true">&hellip;</span><span class="screen-reader-text">%s</span></button></li>',
 			sprintf( /* translators: s=Linback type */
-				__( 'Show fewer %s'),
+				__( 'Show fewer %s', 'semantic-linkbacks' ),
 				$type_labels[$r['type']]
 			)
 		);

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -181,9 +181,37 @@ function list_linkbacks( $args, $comments ) {
 	$return  = sprintf( '<%1$s class="%2$s">', $r['style'], join( ' ', $r['style-class'] ) );
 	$fold_at = (int) get_option( 'semantic_linkbacks_facepiles_fold_limit', 8 );
 
+	$type_labels = [
+		'reacji' => __( 'Reacjis', 'semantic-linkbacks' ),
+		'like' => __( 'Likes', 'semantic-linkbacks' ),
+		'favorite' => __( 'Favourites', 'semantic-linkbacks' ),
+		'bookmark' => __( 'Bookmarks', 'semantic-linkbacks' ),
+		'repost' => __( 'Reposts', 'semantic-linkbacks' ),
+		'tag' => __( 'Tags', 'semantic-linkbacks' ),
+		'listen' => __( 'Listening', 'semantic-linkbacks' ),
+		'read' => __( 'Reading', 'semantic-linkbacks' ),
+		'follow' => __( 'Following', 'semantic-linkbacks' ),
+		'watch' => __( 'Watching', 'semantic-linkbacks' ),
+		'rsvp-yes' => __( 'RSVPs', 'semantic-linkbacks' ),
+		'invited' => __( 'Invited', 'semantic-linkbacks' ),
+		'rsvp-maybe' => __( 'Maybe', 'semantic-linkbacks' ),
+		'rsvp-no' => __( 'No', 'semantic-linkbacks' ),
+		'rsvp-interested' => __( 'Interested', 'semantic-linkbacks' ),
+		'mention' => __( 'Mentions', 'semantic-linkbacks' ),
+	];
+
 	foreach ( $comments as $i => $comment ) {
 		if ( $fold_at && $i === $fold_at ) {
 			$classes[] = 'additional-facepile';
+
+			// Add show button.
+			$return .= sprintf(
+				'<li class="additional-facepile-button-list-item"><button class="show-additional-facepiles"><span aria-hidden="true">&hellip;</span><span class="screen-reader-text">%s</span></button></li>',
+				sprintf( /* translators: s=Linback type */
+					__( 'Show more %s'),
+					$type_labels[$r['type']]
+				)
+			);
 		}
 
 		// If it's an emoji reaction, overlay the emoji.
@@ -227,7 +255,14 @@ function list_linkbacks( $args, $comments ) {
 	}
 
 	if ( $fold_at && count( $comments ) > $fold_at ) {
-		$return .= '<li class="toggle-additional-facepiles">&hellip;</li>';
+		// Add hide button at end.
+		$return .= sprintf(
+			'<li class="additional-facepile-button-list-item is-hidden"><button class="hide-additional-facepiles"><span aria-hidden="true">&hellip;</span><span class="screen-reader-text">%s</span></button></li>',
+			sprintf( /* translators: s=Linback type */
+				__( 'Hide more %s'),
+				$type_labels[$r['type']]
+			)
+		);
 	}
 
 	$return .= sprintf( '</%1$s>', $r['style'] );

--- a/js/semantic-linkbacks.js
+++ b/js/semantic-linkbacks.js
@@ -1,7 +1,43 @@
-jQuery( document ).ready( function() {
-  jQuery( '.additional-facepile' ).hide();
+document.addEventListener( 'DOMContentLoaded', function() {
+  var showAdditionalFacepileButtons = document.querySelectorAll( '.show-additional-facepiles' ),
+    mentionLists = document.querySelectorAll( '.mention-list' );
 
-  jQuery( '.toggle-additional-facepiles' ).click( function() {
-    jQuery( this ).parent( 'ul' ).find( '.additional-facepile' ).toggle();
-  } );
-} );
+  if ( showAdditionalFacepileButtons.length === 0 || mentionLists.length === 0 ) {
+    return;
+  }
+
+  // Add `initialized` class to mention-list container. When JS is disabled or not working, we want to show all items.
+  for ( var i = 0; i < mentionLists.length; i++ ) {
+    var mentionList = mentionLists[i];
+    mentionList.classList.add( 'initialized' );
+  }
+
+  // Loop the buttons to show additional facepiles.
+  for ( var i = 0; i < showAdditionalFacepileButtons.length; i++ ) {
+    var showAdditionalFacepileButton = showAdditionalFacepileButtons[i],
+      hideAdditionalFacepileButton = showAdditionalFacepileButton.parentNode.parentNode.querySelector( '.hide-additional-facepiles' );
+
+    showAdditionalFacepileButton.addEventListener( 'click', function() {
+      toggleListItemClasses( this );
+    } );
+
+    hideAdditionalFacepileButton.addEventListener( 'click', function() {
+      toggleListItemClasses( this );
+    } );
+  }
+
+  /**
+   * Toggle the classes of the list items that contain the buttons.
+   *
+   * @param {HTMLElement} clickedButton
+   */
+  var toggleListItemClasses = function( clickedButton ) {
+    var buttonListItem = clickedButton.parentNode,
+    otherButtonListItem = buttonListItem.classList.contains( 'is-hidden' )
+      ? buttonListItem.parentNode.querySelector( '.additional-facepile-button-list-item:not(.is-hidden)' )
+      : buttonListItem.parentNode.querySelector( '.additional-facepile-button-list-item.is-hidden' );
+
+    buttonListItem.classList.toggle( 'is-hidden' );
+    otherButtonListItem.classList.toggle( 'is-hidden' );
+  }
+});

--- a/semantic-linkbacks.php
+++ b/semantic-linkbacks.php
@@ -150,7 +150,7 @@ class Semantic_Linkbacks_Plugin {
 		wp_enqueue_style( 'semantic-linkbacks-css', plugin_dir_url( __FILE__ ) . 'css/semantic-linkbacks.css', array(), self::$version );
 
 		if ( is_singular() && 0 !== (int) get_option( 'semantic_linkbacks_facepiles_fold_limit', 8 ) ) {
-			wp_enqueue_script( 'semantic-linkbacks', plugin_dir_url( __FILE__ ) . 'js/semantic-linkbacks.js', array( 'jquery' ), self::$version, true );
+			wp_enqueue_script( 'semantic-linkbacks', plugin_dir_url( __FILE__ ) . 'js/semantic-linkbacks.js', array(), self::$version, true );
 		}
 	}
 

--- a/tests/test-rendering.php
+++ b/tests/test-rendering.php
@@ -41,7 +41,7 @@ class RenderingTest extends WP_UnitTestCase {
 		$this->assertStringMatchesFormat(
 			'<ul class="mention-list linkback-mention"><li class="webmention even thread-even depth-1 linkback-mention-single u-like h-cite" id="comment-2">
 				<span class="p-author h-card">
-					<a class="u-url" title="Person 0 liked this Post on example.com." href="http://example.com/person0"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' /> </a>
+					<a class="u-url" title="Person 0 liked this Post on example.com." href="http://example.com/person0"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' loading=\'lazy\'/> </a>
 					<span class="hide-name p-name">Person 0</span>
 				</span>
 				<a class="u-url" href=""></a>
@@ -96,7 +96,7 @@ class RenderingTest extends WP_UnitTestCase {
 	<h3>Reacjis</h3>
 	<ul class="mention-list linkback-reacji"><li class="comment even thread-even depth-1 linkback-reacji-single h-cite" id="comment-%d">
 				<span class="p-author h-card">
-					<a class="u-url" title="Person 😢 on example.com." href="http://example.com/person"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' /> <span class="emoji-overlay">😢</span></a>
+					<a class="u-url" title="Person 😢 on example.com." href="http://example.com/person"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' loading=\'lazy\'/> <span class="emoji-overlay">😢</span></a>
 					<span class="hide-name p-name">Person</span>
 				</span>
 				<a class="u-url" href=""></a>

--- a/tests/test-rendering.php
+++ b/tests/test-rendering.php
@@ -55,7 +55,7 @@ class RenderingTest extends WP_UnitTestCase {
 		$person_0 = strpos( $html, '<a class="u-url" title="Person 0 liked this Post on example.com."' );
 		$person_1 = strpos( $html, '<a class="u-url" title="Person 1 liked this Post on example.com."' );
 		$person_2 = strpos( $html, 'additional-facepile' );
-		$ellipsis = strpos( $html, '<li class="toggle-additional-facepiles">' );
+		$ellipsis = strpos( $html, '<button class="show-additional-facepiles">' );
 		$this->assertGreaterThan( 0, $person_0 );
 		$this->assertGreaterThan( $person_0, $person_1 );
 		$this->assertGreaterThan( $person_1, $person_2 );


### PR DESCRIPTION
I wanted to remove the jQuery dependency and saw that the accessibility of the toggle feature could be improved, so the PR contains the following:

- I rewrote the JS so it does not need jQuery.
- I added button elements to show/hide the additional facepiles, so also users that do not use the mouse can toggle them. I used two here, so that after clicking the button to show more facepiles, the first facepile that was hidden until then will get the focus. Otherwise the focus would be on the end of the list.

Maybe the button to hide the elements again is not really needed and could be dropped?

The changes can be seen in action here: https://florianbrinkmann.com/verzeichnis-kopieren-php-11366/#comments

Closes #213 