### PR TITLE
Refbacks will be handled by their own plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 **Tags:** webmention, pingback, trackback, linkback, microformats, comments, indieweb  
 **Requires at least:** 4.9  
 **Requires PHP:** 5.6  
-**Tested up to:** 5.5  
-**Stable tag:** 3.10.3  
+**Tested up to:** 5.6  
+**Stable tag:** 3.10.4  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 
@@ -85,6 +85,10 @@ The plugin uses a locally cached version of the mystery icon normally provided b
 ## Changelog ##
 
 Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks](https://github.com/pfefferle/wordpress-semantic-linkbacks). Please file support issues there.
+
+### 3.10.4 ###
+
+* Remove refbacks as a default. Add a filter to decide on what comment types would be used.
 
 ### 3.10.3 ###
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Requires at least:** 4.9  
 **Requires PHP:** 5.6  
 **Tested up to:** 5.6  
-**Stable tag:** 3.10.4  
+**Stable tag:** 3.10.3  
 **License:** MIT  
 **License URI:** http://opensource.org/licenses/MIT  
 
@@ -86,12 +86,11 @@ The plugin uses a locally cached version of the mystery icon normally provided b
 
 Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks](https://github.com/pfefferle/wordpress-semantic-linkbacks). Please file support issues there.
 
-### 3.10.4 ###
-
-* Remove refbacks as a default. Add a filter to decide on what comment types would be used.
-
 ### 3.10.3 ###
 
+* Remove jQuery dependency. Props to [Florian Brinkmann](https://github.com/florianbrinkmann).
+* Fix Facepile errors. Props to [Terence Eden](https://github.com/edent).
+* Remove refbacks as a default. Add a filter to decide on what comment types would be used.
 * Use `comment` as default comment-type: https://core.trac.wordpress.org/ticket/49236
 
 ### 3.10.2 ###

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "installer-name": "semantic-linkbacks"
   },
   "require": {
-    "php": ">=5.3.0",
+    "php": ">=5.6.0",
     "composer/installers": "~1.0",
     "mf2/mf2": "*",
     "p3k/emoji-detector": "*"

--- a/includes/class-linkbacks-handler.php
+++ b/includes/class-linkbacks-handler.php
@@ -172,7 +172,7 @@ class Linkbacks_Handler {
 	 */
 	public static function enhance( $commentdata, $comment = array(), $commentarr = array() ) {
 		// check if comment is a linkback
-		if ( ! in_array( $commentdata['comment_type'], array( 'webmention', 'pingback', 'trackback', 'refback' ), true ) ) {
+		if ( ! in_array( $commentdata['comment_type'], apply_filters( 'semantic_linkbacks_enhance_comment_types', array( 'webmention', 'pingback', 'trackback' ) ), true ) ) {
 			return $commentdata;
 		}
 
@@ -205,7 +205,7 @@ class Linkbacks_Handler {
 		if ( isset( $commentdata['comment_meta']['semantic_linkbacks_type'] ) ) {
 			if ( in_array( $commentdata['comment_meta']['semantic_linkbacks_type'], apply_filters( 'semantic_linkbacks_comment_types', array( 'reply' ) ), true ) ) {
 				// https://core.trac.wordpress.org/ticket/49236 - As of WP5.5, comment will be the default comment type, not empty.
-				$commentdata['comment_type'] = version_compare( get_bloginfo( 'version'), '5.5', '>=' ) ? 'comment' : '';
+				$commentdata['comment_type'] = version_compare( get_bloginfo( 'version' ), '5.5', '>=' ) ? 'comment' : '';
 			}
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: webmention, pingback, trackback, linkback, microformats, comments, indiewe
 Requires at least: 4.9
 Requires PHP: 5.6
 Tested up to: 5.6
-Stable tag: 3.10.4
+Stable tag: 3.10.3
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 
@@ -86,12 +86,11 @@ The plugin uses a locally cached version of the mystery icon normally provided b
 
 Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks](https://github.com/pfefferle/wordpress-semantic-linkbacks). Please file support issues there.
 
-= 3.10.4 =
-
-* Remove refbacks as a default. Add a filter to decide on what comment types would be used.
-
 = 3.10.3 =
 
+* Remove jQuery dependency. Props to [Florian Brinkmann](https://github.com/florianbrinkmann).
+* Fix Facepile errors. Props to [Terence Eden](https://github.com/edent).
+* Remove refbacks as a default. Add a filter to decide on what comment types would be used.
 * Use `comment` as default comment-type: https://core.trac.wordpress.org/ticket/49236
 
 = 3.10.2 =

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: https://notiz.blog/donate/
 Tags: webmention, pingback, trackback, linkback, microformats, comments, indieweb
 Requires at least: 4.9
 Requires PHP: 5.6
-Tested up to: 5.5
-Stable tag: 3.10.3
+Tested up to: 5.6
+Stable tag: 3.10.4
 License: MIT
 License URI: http://opensource.org/licenses/MIT
 
@@ -85,6 +85,10 @@ The plugin uses a locally cached version of the mystery icon normally provided b
 == Changelog ==
 
 Project actively developed on Github at [pfefferle/wordpress-semantic-linkbacks](https://github.com/pfefferle/wordpress-semantic-linkbacks). Please file support issues there.
+
+= 3.10.4 =
+
+* Remove refbacks as a default. Add a filter to decide on what comment types would be used.
 
 = 3.10.3 =
 

--- a/semantic-linkbacks.php
+++ b/semantic-linkbacks.php
@@ -5,7 +5,7 @@
  * Description: Semantic Linkbacks for WebMentions, Trackbacks and Pingbacks
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 3.10.3
+ * Version: 3.10.4
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
  * Text Domain: semantic-linkbacks
@@ -23,7 +23,7 @@ add_action( 'admin_init', array( 'Semantic_Linkbacks_Plugin', 'admin_init' ) );
  * @author Matthias Pfefferle
  */
 class Semantic_Linkbacks_Plugin {
-	public static $version = '3.10.1';
+	public static $version = '3.10.4';
 	/**
 	 * Initialize the plugin, registering WordPress hooks.
 	 */

--- a/semantic-linkbacks.php
+++ b/semantic-linkbacks.php
@@ -5,11 +5,11 @@
  * Description: Semantic Linkbacks for WebMentions, Trackbacks and Pingbacks
  * Author: Matthias Pfefferle
  * Author URI: https://notiz.blog/
- * Version: 3.10.4
+ * Version: 3.10.3
  * License: MIT
  * License URI: http://opensource.org/licenses/MIT
  * Text Domain: semantic-linkbacks
- * Requires PHP: 5.4
+ * Requires PHP: 5.6
  */
 
 add_action( 'plugins_loaded', array( 'Semantic_Linkbacks_Plugin', 'init' ), 11 );
@@ -23,7 +23,7 @@ add_action( 'admin_init', array( 'Semantic_Linkbacks_Plugin', 'admin_init' ) );
  * @author Matthias Pfefferle
  */
 class Semantic_Linkbacks_Plugin {
-	public static $version = '3.10.4';
+	public static $version = '3.10.3';
 	/**
 	 * Initialize the plugin, registering WordPress hooks.
 	 */


### PR DESCRIPTION
Would like to update the refbacks plugin, but want to make sure that Semantic Linkbacks will only work on refbacks if the refbacks plugin requests it. Also noting the plugin as compatible with 5.6