### PR TITLE
Remove whitespace from list items

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -219,7 +219,7 @@ function list_linkbacks( $args, $comments ) {
 		$content = trim( wp_strip_all_tags( $comment->comment_content ) );
 		$title   = Linkbacks_Handler::comment_text_excerpt( '', $comment );
 		if ( Emoji\is_single_emoji( $content ) ) {
-			$overlay = '<span class="emoji-overlay">' . $content . '</span>';
+			$overlay = ' <span class="emoji-overlay">' . $content . '</span>';
 			$url     = wp_parse_url( Linkbacks_Handler::get_url( $comment ), PHP_URL_HOST );
 			$title   = sprintf(
 				'%1$s %2$s on %3$s.',
@@ -236,13 +236,7 @@ function list_linkbacks( $args, $comments ) {
 			$avatar = get_comment_author( $comment );
 		}
 		$return .= sprintf(
-			'<li class="%1$s" id="%5$s">
-				<span class="p-author h-card">
-					<a class="u-url" title="%6$s" href="%3$s">%2$s %8$s</a>
-					<span class="hide-name p-name">%4$s</span>
-				</span>
-				<a class="u-url" href="%7$s"></a>
-			</li>',
+			'<li class="%1$s" id="%5$s"><span class="p-author h-card"><a class="u-url" title="%6$s" href="%3$s">%2$s%8$s</a><span class="hide-name p-name">%4$s</span></span><a class="u-url" href="%7$s"></a></li>',
 			$class,
 			$avatar,
 			get_comment_author_url( $comment ),

--- a/tests/test-rendering.php
+++ b/tests/test-rendering.php
@@ -39,13 +39,7 @@ class RenderingTest extends WP_UnitTestCase {
 	public function test_facepile_markup() {
 		$comments = $this->make_comments( 1 );
 		$this->assertStringMatchesFormat(
-			'<ul class="mention-list linkback-mention"><li class="webmention even thread-even depth-1 linkback-mention-single u-like h-cite" id="comment-2">
-				<span class="p-author h-card">
-					<a class="u-url" title="Person 0 liked this Post on example.com." href="http://example.com/person0"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' loading=\'lazy\'/> </a>
-					<span class="hide-name p-name">Person 0</span>
-				</span>
-				<a class="u-url" href=""></a>
-			</li></ul>', list_linkbacks( array( 'echo' => false ), $comments )
+			'<ul class="mention-list linkback-mention"><li class="webmention even thread-even depth-1 linkback-mention-single u-like h-cite" id="comment-2"><span class="p-author h-card"><a class="u-url" title="Person 0 liked this Post on example.com." href="http://example.com/person0"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' loading=\'lazy\'/></a><span class="hide-name p-name">Person 0</span></span><a class="u-url" href=""></a></li></ul>', list_linkbacks( array( 'echo' => false ), $comments )
 		);
 	}
 
@@ -94,13 +88,7 @@ class RenderingTest extends WP_UnitTestCase {
 		$this->assertStringMatchesFormat(
 			'<div class="reactions">
 	<h3>Reacjis</h3>
-	<ul class="mention-list linkback-reacji"><li class="comment even thread-even depth-1 linkback-reacji-single h-cite" id="comment-%d">
-				<span class="p-author h-card">
-					<a class="u-url" title="Person 😢 on example.com." href="http://example.com/person"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' loading=\'lazy\'/> <span class="emoji-overlay">😢</span></a>
-					<span class="hide-name p-name">Person</span>
-				</span>
-				<a class="u-url" href=""></a>
-			</li></ul></div>', trim( $html )
+	<ul class="mention-list linkback-reacji"><li class="comment even thread-even depth-1 linkback-reacji-single h-cite" id="comment-%d"><span class="p-author h-card"><a class="u-url" title="Person 😢 on example.com." href="http://example.com/person"><img alt=\'\' src=\'http://example.com/photo\' srcset=\'http://example.com/photo 2x\' class=\'avatar avatar-64 photo avatar-default u-photo avatar-semantic-linkbacks\' height=\'64\' width=\'64\' loading=\'lazy\'/> <span class="emoji-overlay">😢</span></a><span class="hide-name p-name">Person</span></span><a class="u-url" href=""></a></li></ul></div>', trim( $html )
 		);
 	}
 }


### PR DESCRIPTION
I was trying to format the lists of reactions like a comma-separated list, and had the problem that after each item there was a whitespace. This PR removes that whitespaces with writing the markup in one line and removing a whitespace in the `u-url` anchor for not-emoji-reactions. You can see it live here https://florianbrinkmann.com/auf-ein-neues-beim-projekt26-11556/#comments