### PR TITLE
Fix folder name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,6 @@ rather than rerequesting this information.
 
 ## Installation ##
 
-1. Upload the `webmention`-folder to the `/wp-content/plugins/` directory
+1. Upload the `semantic-linkbacks`-folder to the `/wp-content/plugins/` directory
 2. Activate the plugin through the *Plugins* menu in WordPress
 3. ...and that's it :)


### PR DESCRIPTION
The folder name in the readme’s installation part should be `semantic-linkbacks` (maybe there should be an additional hint that the folder downloaded from GitHub needs to be renamed to match the W.org plugin slug?).